### PR TITLE
Documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ and/or validation (`last-modified`, `etag`) information:
 
 For more information about Rack::Cache features and usage, see:
 
-https://rtomayko.github.com/rack-cache/
+https://rtomayko.github.io/rack-cache/
 
 Rack::Cache is not overly optimized for performance. The main goal of the
 project is to provide a portable, easy-to-configure, and standards-based
@@ -123,4 +123,4 @@ Rack::Cache::Key.query_string_ignore = proc { |k, v| k =~ /^(trk|utm)_/ }
 ```
 
 License: MIT<br/>
-[![Build Status](https://travis-ci.org/rtomayko/rack-cache.svg)](https://travis-ci.org/rtomayko/rack-cache)
+[![Development](https://github.com/rack/rack-cache/actions/workflows/development.yml/badge.svg)](https://github.com/rack/rack-cache/actions/workflows/development.yml)

--- a/doc/index.markdown
+++ b/doc/index.markdown
@@ -16,7 +16,7 @@ News
     [`CHANGES`](http://github.com/rtomayko/rack-cache/blob/1.0/CHANGES) file
     for details.
   * [How to use Rack::Cache with Rails 2.3](http://snippets.aktagon.com/snippets/302-How-to-setup-and-use-Rack-Cache-with-Rails-2-3-0-RC-1) - it's really easy.
-  * [RailsLab's Advanced HTTP Caching Screencast](http://railslab.newrelic.com/2009/02/26/episode-11-advanced-http-caching)
+  * [RailsLab's Advanced HTTP Caching Screencast](https://youtu.be/2UvpMhzkktw)
     is a really great review of HTTP caching concepts and shows how to
     use Rack::Cache with Rails.
 
@@ -88,7 +88,7 @@ point for exploring the basic concepts of HTTP caching:
     especially the short section on
     [How Web Caches Work](http://www.mnot.net/cache_docs/#WORK)
 
-  * Joe Gregorio's [Doing HTTP Caching Right](http://www.xml.com/lpt/a/1642)
+  * Joe Gregorio's [Doing HTTP Caching Right](https://www.xml.com/pub/a/2006/02/01/doing-http-caching-right-introducing-httplib2.html)
 
   * [RFC 2616](http://www.ietf.org/rfc/rfc2616.txt), especially
     [Section 13, "Caching in HTTP"](http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html)

--- a/doc/index.markdown
+++ b/doc/index.markdown
@@ -27,7 +27,7 @@ Installation
 
 Or, from a local working copy:
 
-    $ git clone git://github.com/rake/rack-cache.git
+    $ git clone https://github.com/rack/rack-cache.git
     $ rake package && sudo rake install
 
 Basic Usage

--- a/doc/index.markdown
+++ b/doc/index.markdown
@@ -27,7 +27,7 @@ Installation
 
 Or, from a local working copy:
 
-    $ git clone git://github.com/rtomayko/rack-cache.git
+    $ git clone git://github.com/rake/rack-cache.git
     $ rake package && sudo rake install
 
 Basic Usage
@@ -63,7 +63,7 @@ More
   * [Things Caches Do][things] - an illustrated guide to how HTTP gateway
     caches work with pointers to other useful resources on HTTP caching.
 
-  * [GitHub Repository](http://github.com/rtomayko/rack-cache/) - get your
+  * [GitHub Repository](http://github.com/rack/rack-cache/) - get your
     fork on.
 
   * [Mailing List](http://groups.google.com/group/rack-cache) - for hackers
@@ -74,7 +74,7 @@ More
   * [RDoc API Documentation](./api/) - Mostly worthless if you just want to use
     __Rack::Cache__ in your application but mildly insightful if you'd like to
     get a feel for how the system has been put together; I recommend
-    [reading the source](http://github.com/rtomayko/rack-cache/tree/master/lib/rack/cache).
+    [reading the source](http://github.com/rack/rack-cache/tree/main/lib/rack/cache).
 
 
 See Also

--- a/rack-cache.gemspec
+++ b/rack-cache.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new 'rack-cache', '1.13.0' do |s|
   s.add_development_dependency 'rake'
 
   s.license = "MIT"
-  s.homepage = "https://github.com/rtomayko/rack-cache"
+  s.homepage = "https://github.com/rack/rack-cache"
   s.rdoc_options = ["--line-numbers", "--inline-source", "--title", "Rack::Cache", "--main", "Rack::Cache"]
 end


### PR DESCRIPTION
This would close #6 and do a few other small things.

- Have ci badge point to github action as opposed to old travis ci
- Update links that are dead in index file
- Change most references to `rack/rack-cache`

Also wondering if this repo should have a github pages branch and maybe the other old ones removed.