### PR TITLE
Update doc generation and deploy to github pages

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,26 @@
+name: Github Pages
+on:
+  push:
+    branches:
+      - main
+permissions:
+  contents: write
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.7'
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+      - name: Install and Build 🔧
+        run: bundle exec rake doc:gh-pages
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@v4.3.3
+        with:
+          branch: gh-pages     # The branch the action should deploy to.
+          folder: doc/gh-pages # The folder the action should deploy.

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,5 @@ tags
 /doc/license.html
 /doc/storage.html
 /doc/faq.html
+/doc/gh-pages
 Gemfile.lock
-

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ require 'bump/tasks'
 
 task :default => :test
 
-CLEAN.include %w[coverage/ doc/api tags]
+CLEAN.include %w[coverage/ doc/api doc/gh-pages tags]
 CLOBBER.include %w[dist]
 
 desc 'Run tests'
@@ -58,9 +58,14 @@ FileList['doc/*.markdown'].each do |source|
   CLEAN.include dest
 end
 
-desc 'Publish documentation'
-task 'doc:publish' => :doc do
-  sh 'rsync -avz doc/ gus@tomayko.com:/src/rack-cache'
+desc 'Move documentation to directory for github pages'
+task 'doc:gh-pages' => [:clean, :doc] do
+  html_files = FileList['doc/*.markdown'].map { |file| file.gsub('.markdown', '.html')}
+  css_files = FileList['doc/*.css']
+
+  FileUtils.mkdir('doc/gh-pages')
+  FileUtils.cp_r('doc/api/', 'doc/gh-pages/api')
+  FileUtils.cp([*html_files, *css_files], 'doc/gh-pages')
 end
 
 desc 'Start the documentation development server'

--- a/Rakefile
+++ b/Rakefile
@@ -22,22 +22,17 @@ end
 desc 'Build all documentation'
 task :doc => %w[doc:api doc:markdown]
 
-# requires the hanna gem:
-#   gem install mislav-hanna --source=http://gems.github.com
 desc 'Build API documentation (doc/api)'
 task 'doc:api' => 'doc/api/index.html'
 file 'doc/api/index.html' => FileList['lib/**/*.rb'] do |f|
   rm_rf 'doc/api'
   sh((<<-SH).gsub(/[\s\n]+/, ' ').strip)
-  hanna
+  rdoc
     --op doc/api
-    --promiscuous
     --charset utf8
-    --fmt html
-    --inline-source
+    --fmt hanna
     --line-numbers
-    --accessor option_accessor=RW
-    --main Rack::Cache
+    --main cache.rb
     --title 'Rack::Cache API Documentation'
     #{f.prerequisites.join(' ')}
   SH

--- a/Rakefile
+++ b/Rakefile
@@ -63,7 +63,7 @@ task 'doc:publish' => :doc do
   sh 'rsync -avz doc/ gus@tomayko.com:/src/rack-cache'
 end
 
-desc 'Start the documentation development server (requires thin)'
+desc 'Start the documentation development server'
 task 'doc:server' do
   sh 'cd doc && thin --rackup server.ru --port 3035 start'
 end

--- a/doc/layout.html.erb
+++ b/doc/layout.html.erb
@@ -2,10 +2,8 @@
 <html lang='en'>
   <head>
     <meta http-equiv='content-type' content='text/html;charset=utf-8'>
-    <title>Rack::Cache <%= title %></title>
+    <title>Rack::Cache</title>
     <link rel='stylesheet' href='rack-cache.css' type='text/css' media='all'>
-    <script type='text/javascript' src='http://code.jquery.com/jquery-1.2.3.js'></script>
-    <script type='text/javascript' src='http://tomayko.com/js/tomayko.js'></script>
   </head>
   <body>
     <div id='container'>

--- a/rack-cache.gemspec
+++ b/rack-cache.gemspec
@@ -17,6 +17,9 @@ Gem::Specification.new 'rack-cache', '1.13.0' do |s|
   s.add_development_dependency 'dalli'
   s.add_development_dependency 'bump'
   s.add_development_dependency 'rake'
+  s.add_development_dependency 'thin'
+  s.add_development_dependency 'rdiscount'
+  s.add_development_dependency 'hanna-nouveau'
 
   s.license = "MIT"
   s.homepage = "https://github.com/rack/rack-cache"


### PR DESCRIPTION
- Added the dependencies from the rake file as dev dependencies and updated rakefile
- Added a github action to build the docs and deploy them to github pages on merges to main. The action uses https://github.com/JamesIves/github-pages-deploy-action

I tested the action on my fork and it worked https://heroprotagonist.github.io/rack-cache/