### PR TITLE
Fix gh pages workflow

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -9,9 +9,8 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout 🛎️
-        uses: actions/checkout@v3
-        uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7'
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ and/or validation (`last-modified`, `etag`) information:
 
 For more information about Rack::Cache features and usage, see:
 
-https://rtomayko.github.io/rack-cache/
+https://rack.github.io/rack-cache/
 
 Rack::Cache is not overly optimized for performance. The main goal of the
 project is to provide a portable, easy-to-configure, and standards-based


### PR DESCRIPTION
Relates to #8 

Apologies! I had a commit that I never added to the PR. 
This will make the workflow actually generate the docs. As of right now it [failed](https://github.com/rack/rack-cache/actions/runs/2593556256). 
Made sure this PR works on my fork after being [merged](https://github.com/HeroProtagonist/rack-cache/actions/workflows/pages/pages-build-deployment). 

I also updated the readme so it will point to the newly generated docs.