### PR TITLE
Adds Ruby 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -8,10 +8,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        ruby: [2.4, 2.5, 2.6, 2.7, '3.0', 3.1, truffleruby]
+        ruby: [2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, truffleruby]
     runs-on: ${{matrix.os}}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Installing packages (ubuntu)
       if: matrix.os == 'ubuntu-latest'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,7 @@ require 'stringio'
 
 require 'maxitest/global_must'
 require 'maxitest/autorun'
-require 'mocha/setup'
+require 'mocha/minitest'
 
 # Set the MEMCACHED environment variable as follows to enable testing
 # of the MemCached meta and entity stores.


### PR DESCRIPTION
Also updates the checkout action version.

To get specs to run (with all Rubies) I needed to update the require used to load mocha.