### PR TITLE
test: Add explicit 'timeout' require

### DIFF
--- a/test/context_test.rb
+++ b/test/context_test.rb
@@ -1,4 +1,5 @@
 require_relative 'test_helper'
+require 'timeout'
 require 'rack/cache/context'
 
 describe Rack::Cache::Context do


### PR DESCRIPTION
Fixes the following when running tests individually:
```
  1) Error:
Rack::Cache::Context#test_0078_passes if there was a metastore exception:
NameError: uninitialized constant Timeout
    test/context_test.rb:981:in `block (3 levels) in <top (required)>'
    test/test_helper.rb:170:in `request'
    test/test_helper.rb:177:in `get'
    test/context_test.rb:980:in `block (2 levels) in <top (required)>'
```