### PR TITLE
Update reference to MiniTest -> Minitest

### DIFF
--- a/test/meta_store_test.rb
+++ b/test/meta_store_test.rb
@@ -182,7 +182,7 @@ module RackCacheMetaStoreImplementation
       it 'purges meta store entry when the body does not exist' do
         store_simple_entry
         @entity_store.purge(@response.headers['x-content-digest'])
-        mock = MiniTest::Mock.new
+        mock = Minitest::Mock.new
         mock.expect :call, nil, [@store.cache_key(@request)]
         @store.stub(:purge, mock) do
           @store.lookup(@request, @entity_store)


### PR DESCRIPTION
Fixes reference to `Minitest` namespace when instantiating a `Minitest::Mock`, as noted [here](https://github.com/rack/rack-cache/pull/16#issuecomment-1686242556).

```
  1) Error:
Rack::Cache::MetaStore::Disk#test_0023_purges meta store entry when the body does not exist:
NameError: uninitialized constant RackCacheMetaStoreImplementation::MiniTest
Did you mean?  Minitest
               Maxitest
    test/meta_store_test.rb:185:in `block (2 levels) in included'
```