### PR TITLE
Ensure invalidate doesn't mutate response x-status key

### DIFF
--- a/lib/rack/cache/meta_store.rb
+++ b/lib/rack/cache/meta_store.rb
@@ -124,10 +124,8 @@ module Rack::Cache
           if response.fresh?
             response.expire!
             modified = true
-            [req, persist_response(response)]
-          else
-            [req, res]
           end
+          [req, persist_response(response)]
         end
       write key, entries if modified
     end


### PR DESCRIPTION
I ran into an issue where our application was serving responses with HTTP status code 0. I noticed that some of our metastore cache entries didn't have an `x-status` key.

I found that this occurs on `invalidate` when at least one entry is fresh. In this case all stale entries are written back to the cache without `x-status`.

It seem that the method to restore responses mutates the x-status key in the header hash (resp), and then the same, modified object is written back to the cache.
https://github.com/rack/rack-cache/blob/0ffee48e1e7904d1e2d8a2f46695d3e38ba43285/lib/rack/cache/meta_store.rb#L147

This change removes that possibility by always using the rehydrated response when mapping over the entries to invalidate.

This surfaced in my app during the upgrade to Rails 6.1, but I haven't figured out that part of the equation yet.